### PR TITLE
Feature/core 702 onboarding feedback

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -16,6 +16,8 @@
   - fix `evan-control` without label width
 
 ### Deprecations
+- `evancore.vue.libs` (v1.9.0)
+  - remove company name from registration entry
 
 
 ## Version 1.8.0

--- a/dapps/evancore.vue.libs/dbcp.json
+++ b/dapps/evancore.vue.libs/dbcp.json
@@ -21,7 +21,7 @@
         "evancore.vue.libs.js",
         "evancore.vue.libs.css"
       ],
-      "origin": "QmcM1iXSTySkQ5G77WzesHRBb6BLn6TC9PQ1QhZvxoybiV",
+      "origin": "QmUZkLkKGPigghJtZKwoUXM83vfZKiZVUbaFj3Rhqt9xy9",
       "primaryColor": "",
       "secondaryColor": "#f9f9ff",
       "standalone": false,
@@ -58,7 +58,7 @@
       "1.5.0": "QmTsoKExPyhicJxaCAbt5XWm92Y81LhPjRTYMkAeBoVutQ",
       "1.6.0": "QmVdyNw3WbY3pmYHLyiVBtNRrrHqToL3JuNp7AFzrmHtEC",
       "1.7.0": "Qmc2UaDBLgZDAmXD5rguaufaL6w7kUuRRkx1c2NcwDZL6F",
-      "1.8.0": "QmUGS11J3KAHtCyJxPTGtSwYhiG74GGmLmhDTX376vHZ8T"
+      "1.8.0": "QmVjt7epo22ZWmS3phA5DvqRRHeZXSYGMhTV8X6Tm18Y9v"
     }
   }
 }

--- a/dapps/evancore.vue.libs/src/components/forms/form/form.ts
+++ b/dapps/evancore.vue.libs/src/components/forms/form/form.ts
@@ -220,22 +220,32 @@ export default class EvanFormComponent extends mixins(EvanComponent) {
 
     // return directly specified translation
     let returnTranslation = type !== 'hint';
-    if (control.uiSpecs && control.uiSpecs.attr &&
-        control.uiSpecs.attr.hasOwnProperty(type)) {
+    if (control.uiSpecs &&
+        (control.uiSpecs.hasOwnProperty(type) ||
+          (control.uiSpecs.attr && control.uiSpecs.attr.hasOwnProperty(type)))
+      ) {
+      // allow property definition within uiSpecis and within attr (specifing label within attr would be confusing)
+      const specOverwrite = control.uiSpecs.attr && control.uiSpecs.attr[type] ?
+        control.uiSpecs.attr[type] : control.uiSpecs[type];
+      // if the attribute is a dynamic function, execute and return the value
+      if (typeof specOverwrite === 'function') {
+        return specOverwrite();
+      }
+
       // if it's a hint, check if it's set to true or string
       if (type === 'hint') {
-        if (control.uiSpecs.attr.hint) {
+        if (specOverwrite) {
           // if true, enable hint translation
-          if (typeof control.uiSpecs.attr.hint === 'boolean') {
+          if (typeof specOverwrite === 'boolean') {
             returnTranslation = true;
           } else {
             // for a string directly return it
-            return this.$t(control.uiSpecs.attr.hint);
+            return this.$t(specOverwrite);
           }
         }
         // else, disable the hint
       } else {
-        return this.$t(control.uiSpecs.attr[type]);
+        return this.$t(specOverwrite);
       }
     }
 

--- a/dapps/evancore.vue.libs/src/components/forms/form/form.ts
+++ b/dapps/evancore.vue.libs/src/components/forms/form/form.ts
@@ -206,11 +206,12 @@ export default class EvanFormComponent extends mixins(EvanComponent) {
    * Return the translation for a control specific text (label, placeholder, error)
    *
    * @param      {EvanFormControl}  control  control that should be translated
-   * @param      {string}           type     text that should be translated (label, placeholder, error)
+   * @param      {string}           attr     attribute that should be translated (label,
+   *                                         placeholder, error)
    */
-  getTranslation(control: EvanFormControl, type: string) {
+  getTranslation(control: EvanFormControl, attr: string) {
     // if manual error text was specified, translate it and return it directly
-    if (type === 'error') {
+    if (attr === 'error') {
       if (typeof control.error !== 'boolean') {
         return this.$t(control.error);
       } else if (!control.error) {
@@ -219,18 +220,18 @@ export default class EvanFormComponent extends mixins(EvanComponent) {
     }
 
     // return directly specified translation
-    let returnTranslation = type !== 'hint';
-    if (this.hasControlType(control, type)) {
+    let returnTranslation = attr !== 'hint';
+    if (this.hasControlAttr(control, attr)) {
       // allow property definition within uiSpecis and within attr (specifing label within attr would be confusing)
-      const specOverwrite = control.uiSpecs.attr && control.uiSpecs.attr[type] ?
-        control.uiSpecs.attr[type] : control.uiSpecs[type];
+      const specOverwrite = control.uiSpecs.attr && control.uiSpecs.attr[attr] ?
+        control.uiSpecs.attr[attr] : control.uiSpecs[attr];
       // if the attribute is a dynamic function, execute and return the value
       if (typeof specOverwrite === 'function') {
         return specOverwrite();
       }
 
       // if it's a hint, check if it's set to true or string
-      if (type === 'hint') {
+      if (attr === 'hint') {
         if (specOverwrite) {
           // if true, enable hint translation
           if (typeof specOverwrite === 'boolean') {
@@ -248,7 +249,7 @@ export default class EvanFormComponent extends mixins(EvanComponent) {
 
     if (returnTranslation) {
       // return default translation
-      return this.$t(`${ this.i18nScope }.${ control.name }.${ type }`);
+      return this.$t(`${ this.i18nScope }.${ control.name }.${ attr }`);
     } else {
       return '';
     }
@@ -270,18 +271,19 @@ export default class EvanFormComponent extends mixins(EvanComponent) {
   }
 
   /**
-   * Overwrites a control a specific attribute.
+   * Checks if a custom attribute value was applied to a control object.
    *
    * @param      {EvanFormControl}  control  control that should be checked
-   * @param      {string}           type     type that is overwritten (placeholder, hint, ...)
+   * @param      {string}           attr     attr that is overwritten (placeholder, hint, ...)
+   * @return     {boolean} has custom attribute or not
    */
-  hasControlType(control: EvanFormControl, type: string) {
+  hasControlAttr(control: EvanFormControl, attr: string) {
     let hasControl = false;
 
     if (control.uiSpecs) {
-      if (control.uiSpecs.hasOwnProperty(type)) {
+      if (control.uiSpecs.hasOwnProperty(attr)) {
         hasControl = true;
-      } else if (control.uiSpecs.attr && control.uiSpecs.attr.hasOwnProperty(type)) {
+      } else if (control.uiSpecs.attr && control.uiSpecs.attr.hasOwnProperty(attr)) {
         hasControl = true;
       }
     }

--- a/dapps/evancore.vue.libs/src/components/forms/form/form.ts
+++ b/dapps/evancore.vue.libs/src/components/forms/form/form.ts
@@ -220,10 +220,7 @@ export default class EvanFormComponent extends mixins(EvanComponent) {
 
     // return directly specified translation
     let returnTranslation = type !== 'hint';
-    if (control.uiSpecs &&
-        (control.uiSpecs.hasOwnProperty(type) ||
-          (control.uiSpecs.attr && control.uiSpecs.attr.hasOwnProperty(type)))
-      ) {
+    if (this.hasControlType(control, type)) {
       // allow property definition within uiSpecis and within attr (specifing label within attr would be confusing)
       const specOverwrite = control.uiSpecs.attr && control.uiSpecs.attr[type] ?
         control.uiSpecs.attr[type] : control.uiSpecs[type];
@@ -270,5 +267,25 @@ export default class EvanFormComponent extends mixins(EvanComponent) {
     }
 
     return `evan-form-control-${ type }`;
+  }
+
+  /**
+   * Overwrites a control a specific attribute.
+   *
+   * @param      {EvanFormControl}  control  control that should be checked
+   * @param      {string}           type     type that is overwritten (placeholder, hint, ...)
+   */
+  hasControlType(control: EvanFormControl, type: string) {
+    let hasControl = false;
+
+    if (control.uiSpecs) {
+      if (control.uiSpecs.hasOwnProperty(type)) {
+        hasControl = true;
+      } else if (control.uiSpecs.attr && control.uiSpecs.attr.hasOwnProperty(type)) {
+        hasControl = true;
+      }
+    }
+
+    return hasControl;
   }
 }

--- a/dapps/evancore.vue.libs/src/components/forms/form/form.vue
+++ b/dapps/evancore.vue.libs/src/components/forms/form/form.vue
@@ -39,7 +39,11 @@
         {{ '_evan.share' | translate }}
       </evan-button>
     </div>
-    <div class="px-0 pt-4" :class="{ 'container': stacked }">
+    <div class="px-0"
+      :class="{
+        'container': stacked,
+        'pt-4': !onlyForm,
+      }">
       <form class="d-flex flex-wrap flex-row justify-content-between" @submit="save">
         <slot v-bind:setEditMode="setEditMode"></slot>
         <slot name="form" v-if="form">

--- a/dapps/evancore.vue.libs/src/components/profile/profile-preview/profile-preview.ts
+++ b/dapps/evancore.vue.libs/src/components/profile/profile-preview/profile-preview.ts
@@ -106,6 +106,8 @@ export default class ProfilePreviewComponent extends mixins(EvanComponent) {
       this.userInfo = this.accountDetails;
       // transform to correct format
       await this.fillEmptyProfileData();
+      // setup reset value for edit mode cancel
+      this.setOriginalUserInfo();
     } else {
       await this.loadUserInfo();
     }
@@ -143,8 +145,8 @@ export default class ProfilePreviewComponent extends mixins(EvanComponent) {
     // ensure profile picture is set and transformed to ui file
     await this.fillEmptyProfileData();
 
-    // backup user info, so we can revert last changes
-    this.originUserInfo = cloneDeep(bcc.lodash, this.userInfo);
+    // setup reset value for edit mode cancel
+    this.setOriginalUserInfo();
 
     this.$emit('update', this.userInfo);
     this.loading = false;
@@ -218,5 +220,13 @@ export default class ProfilePreviewComponent extends mixins(EvanComponent) {
     this.userInfo.picture.files = await Promise.all(this.userInfo.picture.files.map(async file =>
       FileHandler.fileToContainerFile(file)
     ));
+  }
+
+  /**
+   * Overwrites the reset value, when the user cancels the edit mode.
+   */
+  setOriginalUserInfo() {
+    // backup user info, so we can revert last changes
+    this.originUserInfo = cloneDeep(bcc.lodash, this.userInfo);
   }
 }

--- a/dapps/evancore.vue.libs/src/components/profile/profile-preview/profile-preview.ts
+++ b/dapps/evancore.vue.libs/src/components/profile/profile-preview/profile-preview.ts
@@ -107,7 +107,7 @@ export default class ProfilePreviewComponent extends mixins(EvanComponent) {
       // transform to correct format
       await this.fillEmptyProfileData();
       // setup reset value for edit mode cancel
-      this.setOriginalUserInfo();
+      this.backupUserInfo();
     } else {
       await this.loadUserInfo();
     }
@@ -146,7 +146,7 @@ export default class ProfilePreviewComponent extends mixins(EvanComponent) {
     await this.fillEmptyProfileData();
 
     // setup reset value for edit mode cancel
-    this.setOriginalUserInfo();
+    this.backupUserInfo();
 
     this.$emit('update', this.userInfo);
     this.loading = false;
@@ -223,10 +223,9 @@ export default class ProfilePreviewComponent extends mixins(EvanComponent) {
   }
 
   /**
-   * Overwrites the reset value, when the user cancels the edit mode.
+   * Backups the current user info, so we can revert last changes.
    */
-  setOriginalUserInfo() {
-    // backup user info, so we can revert last changes
+  backupUserInfo() {
     this.originUserInfo = cloneDeep(bcc.lodash, this.userInfo);
   }
 }

--- a/dapps/evancore.vue.libs/src/components/profile/profile-preview/profile-preview.vue
+++ b/dapps/evancore.vue.libs/src/components/profile/profile-preview/profile-preview.vue
@@ -46,7 +46,7 @@
         <template v-if="!isEditMode">
           <a class="force-oneline account-name"
             :href="canEdit() ? null : `${ dapp.baseUrl }/${ dapp.rootEns }/profile.vue.${ dapp.domainName }/${ address }/detail`"
-            @click="userInfo.profileType !== 'company' && startEditing();">
+            @click="startEditing();">
             <h2 class="font-weight-semibold mb-0">
               {{ userInfo.accountName }}
             </h2>
@@ -57,16 +57,7 @@
         </template>
 
         <template v-else>
-          <a
-            class="force-oneline account-name"
-            v-if="userInfo.profileType === 'company'"
-            :href="canEdit() ? null : `${ dapp.baseUrl }/${ dapp.rootEns }/profile.vue.${ dapp.domainName }/${ address }/detail`">
-            <h2 class="font-weight-semibold mb-0">
-              {{ userInfo.accountName }}
-            </h2>
-          </a>
           <evan-form-control-input
-            v-else
             id="accountName"
             ref="accountName"
             type="text"

--- a/dapps/evancore.vue.libs/src/components/profile/wallet/wallet.scss
+++ b/dapps/evancore.vue.libs/src/components/profile/wallet/wallet.scss
@@ -20,18 +20,26 @@
 @import '~@evan.network/ui/src/style/utils';
 $walletYellow: #fbe19e;
 
+.wallet-container {
+  position: relative;
+
+  width: 85.60mm;
+  height: 53.98mm;
+}
+
 .evan-wallet {
   position: relative;
 
   display: block;
+  overflow: hidden;
 
-  height: 200px;
+  width: 100%;
+  height: 100%;
   padding: 1.5em;
 
+  border-radius: 15px;
   background-repeat: no-repeat;
   background-size: cover;
-  border-radius: 15px;
-  overflow: hidden;
 
   &, * {
     text-decoration: none !important;
@@ -63,9 +71,10 @@ $walletYellow: #fbe19e;
     small:first-child {
       font-weight: bold;
 
+      display: block;
+
       margin: 0;
 
-      display: block;
       color: $walletYellow;
     }
 
@@ -77,8 +86,8 @@ $walletYellow: #fbe19e;
 
 .qr-code-open {
   position: absolute;
-  top: calc(50% - 16px);
-  right: 15%;
+  top: calc(50% - 18px);
+  right: 5%;
 
   display: flex;
   align-items: center;
@@ -97,7 +106,7 @@ $walletYellow: #fbe19e;
 }
 
 .qrcode-modal {
-   /deep/ .modal-header,  /deep/ .modal-footer {
+  /deep/ .modal-header, /deep/ .modal-footer {
     display: none !important;
   }
 

--- a/dapps/evancore.vue.libs/src/components/profile/wallet/wallet.ts
+++ b/dapps/evancore.vue.libs/src/components/profile/wallet/wallet.ts
@@ -102,7 +102,9 @@ export default class ProfilePreviewComponent extends mixins(EvanComponent) {
       })(),
       (async () => {
         // load balance and parse it to 3 decimal places
-        const amount = parseFloat((await dappBrowser.core.getBalance(this.address)).toFixed(3));
+        const amount = Math
+          .floor(parseFloat(await dappBrowser.core.getBalance(this.address)))
+          .toFixed(2);
         this.balance = {
           amount: amount.toLocaleString(this.$i18n.locale()),
           timestamp: Date.now(),

--- a/dapps/evancore.vue.libs/src/components/profile/wallet/wallet.ts
+++ b/dapps/evancore.vue.libs/src/components/profile/wallet/wallet.ts
@@ -102,11 +102,10 @@ export default class ProfilePreviewComponent extends mixins(EvanComponent) {
       })(),
       (async () => {
         // load balance and parse it to 3 decimal places
-        const amount = Math
-          .floor(parseFloat(await dappBrowser.core.getBalance(this.address)))
-          .toFixed(2);
+        const amount = Math.floor(parseFloat(
+          await dappBrowser.core.getBalance(this.address)) * 100) / 100;
         this.balance = {
-          amount: amount.toLocaleString(this.$i18n.locale()),
+          amount: amount.toFixed(2).toLocaleString(this.$i18n.locale()),
           timestamp: Date.now(),
         };
       })(),

--- a/dapps/evancore.vue.libs/src/components/profile/wallet/wallet.vue
+++ b/dapps/evancore.vue.libs/src/components/profile/wallet/wallet.vue
@@ -19,7 +19,7 @@
 
 <template>
   <div>
-    <div class="position-relative evan-highlight">
+    <div class="wallet-container evan-highlight">
       <a class="evan-wallet"
         :href="walletLink"
         :style="{
@@ -38,7 +38,7 @@
           </div>
         </template>
       </a>
-      <div class="qr-code-open evan-highlight"
+      <div class="qr-code-open"
         @click="showQRCode($event)">
         <i class="mdi mdi-qrcode-scan"></i>
       </div>

--- a/dapps/evancore.vue.libs/src/i18n/de.json
+++ b/dapps/evancore.vue.libs/src/i18n/de.json
@@ -89,7 +89,7 @@
     "not-your-account": "Nicht Ihr Account?",
     "optional": "optional",
     "password": "Passwort",
-    "password-placeholder": "Passwort der Profilerstellung",
+    "password-placeholder": "Passwort",
     "permission": {
       "hint": "Alle Berechtigungen entziehen?",
       "type": {

--- a/dapps/evancore.vue.libs/src/i18n/de.json
+++ b/dapps/evancore.vue.libs/src/i18n/de.json
@@ -89,7 +89,7 @@
     "not-your-account": "Nicht Ihr Account?",
     "optional": "optional",
     "password": "Passwort",
-    "password-placeholder": "Passwort von der ursprünglichen Profilerstellung",
+    "password-placeholder": "Passwort der Profilerstellung",
     "permission": {
       "hint": "Alle Berechtigungen entziehen?",
       "type": {

--- a/dapps/evancore.vue.libs/src/i18n/en.json
+++ b/dapps/evancore.vue.libs/src/i18n/en.json
@@ -89,7 +89,7 @@
     "not-your-account": "Not your account?",
     "optional": "optional",
     "password": "Password",
-    "password-placeholder": "Password from the original profile creation",
+    "password-placeholder": "Password from sign up",
     "permission": {
       "hint": "Remove all permissions?",
       "type": {

--- a/dapps/evancore.vue.libs/src/i18n/en.json
+++ b/dapps/evancore.vue.libs/src/i18n/en.json
@@ -89,7 +89,7 @@
     "not-your-account": "Not your account?",
     "optional": "optional",
     "password": "Password",
-    "password-placeholder": "Password from sign up",
+    "password-placeholder": "Password",
     "permission": {
       "hint": "Remove all permissions?",
       "type": {


### PR DESCRIPTION
- onboarding
  - auto focus on company field
  - back buttons
  - Company placeholder nicht evan GmbH => Muster GmbH
  - input focus style
  - Sales Tax ID => VAT ID
  - Registration Number => Choose...
  - Recaptcha als letzte Checkbox
  - login password placeholder
  - terms of use design
  - company registration => switch registration page and contact page
  - remove registration page for non germany companies
- twin onboarding
  - images are hopping
  - rename gender to category
  - remove "vollständige" from history description
  - changes are allowed in future
  - i guess already known, but text on first page has around 3 times "Zwilling", 1 time "Twin", last page has 1 "Twin" and 1 "Zwilling"